### PR TITLE
do not add null to end of base64, change pad char to '.'

### DIFF
--- a/libraries/base64/base64.c
+++ b/libraries/base64/base64.c
@@ -22,7 +22,7 @@
 int base64encode(const void* data_buf, size_t dataLength, char* result, size_t resultSize)
 {
    const char base64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-   const char base64pad = '"';
+   const char base64pad = '.';
    const uint8_t *data = (const uint8_t *)data_buf;
    size_t resultIndex = 0;
    size_t x;
@@ -90,7 +90,7 @@ int base64encode(const void* data_buf, size_t dataLength, char* result, size_t r
          result[resultIndex++] = base64pad;
       } 
    }
-   if(resultIndex >= resultSize) return 1;   /* indicate failure: buffer too small */
-   result[resultIndex] = 0;
+   //if(resultIndex >= resultSize) return 1;   /* indicate failure: buffer too small */
+   //result[resultIndex] = 0; Do not null-terminate
    return 0;   /* indicate success */
 }


### PR DESCRIPTION
This avoids appending extra "0x00" to eddystone URLs which would be interpreted as ".com" as per Eddystone specification. It also avoids library errors on too long data when the buffer is tailored to URL length. 

Using dot instead of '"' for URL-safety, note that some applications might require a trailing slash to URL: http://stackoverflow.com/a/7108804 .