### PR TITLE
Fix Makefile for Windows platform. Remove nonexistent includes from b…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ nRF5_SDK_12.0.0_12f24da.zip
 nRF5_SDK_12.1.0_0d23e2a
 nRF5_SDK_12.1.0_0d23e2a.zip
 nRF5_SDK_12.2.*
+nRF5_SDK_12.3.*
 nRF5_SDK_13.*

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SDK_HOME    := $(TOP)/$(SDK_DIR)
 
 ifeq ($(OS),Windows_NT)
 	DOWNLOAD_CMD ?= powershell curl -o
-	UNZIP_CMD ?= powershell Expand-Archive -DestinationPath 
+	UNZIP_CMD ?= powershell Expand-Archive -DestinationPath .
 else
 	DOWNLOAD_CMD ?= curl -o
 	UNZIP_CMD ?= unzip -q
@@ -35,7 +35,6 @@ bootstrap: $(SDK_FILE) $(SDK_DIR) $(SDK_DIR)/external/micro-ecc/micro-ecc
 	@echo SDK_HOME = ${SDK_HOME}
 
 $(SDK_DIR):
-	#$(UNZIP_CMD) $(SDK_DIR) $(SDK_FILE)
 	$(UNZIP_CMD) $(SDK_FILE)
 	$(call patch_sdk_$(SDK_VERSION))
 

--- a/bootloader/ruuvitag_b3_debug/armgcc/Makefile
+++ b/bootloader/ruuvitag_b3_debug/armgcc/Makefile
@@ -81,7 +81,6 @@ INC_FOLDERS += \
   $(SDK_ROOT)/components/drivers_nrf/delay \
   $(SDK_ROOT)/components/ble/common \
   $(SDK_ROOT)/components/libraries/fifo \
-  $(SDK_ROOT)/components/libraries/bootloader/ble_dfu/includes \
   $(SDK_ROOT)/components/libraries/svc \
   $(SDK_ROOT)/components/libraries/log \
   $(SDK_ROOT)/components/libraries/hci \

--- a/bootloader/ruuvitag_b3_production/armgcc/Makefile
+++ b/bootloader/ruuvitag_b3_production/armgcc/Makefile
@@ -83,7 +83,6 @@ INC_FOLDERS += \
   $(SDK_ROOT)/components/drivers_nrf/rng/ \
   $(SDK_ROOT)/components/ble/common \
   $(SDK_ROOT)/components/libraries/fifo \
-  $(SDK_ROOT)/components/libraries/bootloader/ble_dfu/includes \
   $(SDK_ROOT)/components/libraries/svc \
   $(SDK_ROOT)/components/libraries/log \
   $(SDK_ROOT)/components/libraries/hci \


### PR DESCRIPTION
…ootloader Makefiles. Update .gitignore to include the current SDK version.

Without "-DestinationPath" the unzipping will default to the name of the zip, creating wrong directory structure, and without the dot powershell will prompt for the target directory.

The # character does not work as a comment in Powershell, and make will simply try to execute it, resulting in a command not found error