### PR TITLE
Fixed make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ clean:
 	$(MAKE) -C ruuvi_examples/ble_app_beacon/ruuvitag_b/s132/armgcc clean
 	$(MAKE) -C ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc clean
 	$(MAKE) -C ruuvi_examples/test_drivers/ruuvitag_b/s132/armgcc clean
-	$(MAKE) -C ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc
+	$(MAKE) -C ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc clean
 	$(MAKE) -C bootloader/ruuvitag_b_debug/armgcc clean
 	$(MAKE) -C bootloader/ruuvitag_b_production/armgcc clean
 


### PR DESCRIPTION
Fixed the make clean target, as one of the sub-targets was missing the "clean" argument and thus seemed to compile rather than clean: `$(MAKE) -C ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc` which this PR changes to `$(MAKE) -C ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc clean`