### PR TITLE
Fixed is_ble_connected by more explicit return condition

### DIFF
--- a/drivers/bluetooth/ble_event_handlers.c
+++ b/drivers/bluetooth/ble_event_handlers.c
@@ -22,7 +22,7 @@ nrf_ble_qwr_t                            m_qwr;                                 
 /** Return true if connected **/
 bool is_ble_connected()
 {
-  return !BLE_CONN_HANDLE_INVALID == m_conn_handle;
+  return !(BLE_CONN_HANDLE_INVALID == m_conn_handle);
 }
 
 /**@brief Function for dispatching a system event to interested modules.


### PR DESCRIPTION
When I forked the ruuvitag_fw on GitHub and trying make ... it failed on drivers/bluetooth/ble_event_handlers.c line 25 due to `logical not is only applied to the left hand side of comparison` error. This is on a Xubuntu 16.04.3 clean virtual machine, using the GNU ARM Embedded PPA setup (from the README). Making the return condition check more explicit (as is done in this PR) allowed my make to pass this station. It makes sense to me to be more explicit like this, but I don't know if it doesn't cause any negative side-effects.