### PR TITLE
Cleanup of the Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-#
-#
-#
+# Main makefile of ruuvi/ruuvitag_fw
 
 ifeq ($(OS),Windows_NT)
 	TOP := %cd%
@@ -22,7 +20,6 @@ ifeq ($(OS),Windows_NT)
 else
 	DOWNLOAD_CMD ?= curl -o
 	UNZIP_CMD ?= unzip -q
-	#UNZIP_CMD ?= unzip -q -d
 endif
 
 export $(SDK_HOME)
@@ -46,17 +43,14 @@ $(SDK_DIR)/external/micro-ecc/micro-ecc:
 	git clone https://github.com/kmackay/micro-ecc.git $(SDK_DIR)/external/micro-ecc/micro-ecc
 	$(MAKE) -C $(SDK_DIR)/external/micro-ecc/nrf52_armgcc/armgcc
 
-
-
 fw:
 	@echo build FW
 	git submodule sync
 	git submodule update --init --recursive
 	$(MAKE) -C ruuvi_examples/ble_app_beacon/ruuvitag_b/s132/armgcc
 	$(MAKE) -C ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc
-	$(MAKE) -C ruuvi_examples/test_drivers/ruuvitag_b/s132/armgcc
 	$(MAKE) -C ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc
-
+	$(MAKE) -C ruuvi_examples/test_drivers/ruuvitag_b/s132/armgcc
 
 bootloader:
 	@echo build bootloader
@@ -69,8 +63,8 @@ clean:
 	git submodule update --init --recursive
 	$(MAKE) -C ruuvi_examples/ble_app_beacon/ruuvitag_b/s132/armgcc clean
 	$(MAKE) -C ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc clean
-	$(MAKE) -C ruuvi_examples/test_drivers/ruuvitag_b/s132/armgcc clean
 	$(MAKE) -C ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc clean
+	$(MAKE) -C ruuvi_examples/test_drivers/ruuvitag_b/s132/armgcc clean
 	$(MAKE) -C bootloader/ruuvitag_b_debug/armgcc clean
 	$(MAKE) -C bootloader/ruuvitag_b_production/armgcc clean
 

--- a/bootloader/ruuvitag_b_debug/armgcc/Makefile
+++ b/bootloader/ruuvitag_b_debug/armgcc/Makefile
@@ -7,6 +7,7 @@ PROJ_DIR := $(abspath ../..)
 
 $(OUTPUT_DIRECTORY)/ruuvitag_b_bootloader.out: \
   LINKER_SCRIPT := secure_dfu_gcc_nrf52_debug.ld
+
 # Source files common to all targets
 SRC_FILES += \
   $(PROJ_DIR)/dfu_public_key.c \
@@ -183,15 +184,15 @@ LDFLAGS += -Wl,--gc-sections
 # use newlib in nano version
 LDFLAGS += --specs=nano.specs -lc -lnosys
 
+.PHONY: $(TARGETS) default all clean help flash
 
-.PHONY: $(TARGETS) default all clean help flash 
 # Default target - first one defined
 default: ruuvitag_b_bootloader
 
 # Print all targets that can be built
 help:
 	@echo following targets are available:
-	@echo ruuvitag_b_bootloader
+	@echo   ruuvitag_b_bootloader
 
 TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
 

--- a/bootloader/ruuvitag_b_production/armgcc/Makefile
+++ b/bootloader/ruuvitag_b_production/armgcc/Makefile
@@ -6,7 +6,8 @@ SDK_ROOT := $(abspath ../../../nRF5_SDK_12.3.0_d7731ad)
 PROJ_DIR := $(abspath ../..)
 
 $(OUTPUT_DIRECTORY)/ruuvitag_b_bootloader.out: \
-  LINKER_SCRIPT  := secure_dfu_gcc_nrf52_production.ld
+  LINKER_SCRIPT := secure_dfu_gcc_nrf52_production.ld
+
 # Source files common to all targets
 SRC_FILES += \
   $(PROJ_DIR)/dfu_public_key.c \
@@ -185,15 +186,15 @@ LDFLAGS += -Wl,--gc-sections
 # use newlib in nano version
 LDFLAGS += --specs=nano.specs -lc -lnosys
 
+.PHONY: $(TARGETS) default all clean help flash
 
-.PHONY: $(TARGETS) default all clean help flash 
 # Default target - first one defined
 default: ruuvitag_b_bootloader
 
 # Print all targets that can be built
 help:
 	@echo following targets are available:
-	@echo ruuvitag_b_bootloader
+	@echo   ruuvitag_b_bootloader
 
 TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
 

--- a/ruuvi_examples/ble_app_beacon/ruuvitag_b/s132/armgcc/Makefile
+++ b/ruuvi_examples/ble_app_beacon/ruuvitag_b/s132/armgcc/Makefile
@@ -6,7 +6,8 @@ SDK_ROOT := ../../../../../nRF5_SDK_12.3.0_d7731ad
 PROJ_DIR := ../../..
 
 $(OUTPUT_DIRECTORY)/nrf52832_xxaa.out: \
-  LINKER_SCRIPT  := ble_app_beacon_gcc_nrf52.ld
+  LINKER_SCRIPT := ble_app_beacon_gcc_nrf52.ld
+
 # Source files common to all targets
 SRC_FILES += \
   $(PROJ_DIR)/main.c \
@@ -208,20 +209,15 @@ LDFLAGS += -Wl,--gc-sections
 # use newlib in nano version
 LDFLAGS += --specs=nano.specs -lc -lnosys
 
+.PHONY: $(TARGETS) default all clean help flash flash_softdevice
 
-
-
-
-
-
-.PHONY: $(TARGETS) default all clean help flash  flash_softdevice
 # Default target - first one defined
 default: nrf52832_xxaa
 
 # Print all targets that can be built
 help:
 	@echo following targets are available:
-	@echo 	nrf52832_xxaa
+	@echo   nrf52832_xxaa
 
 TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
 

--- a/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
+++ b/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
@@ -6,7 +6,7 @@ SDK_ROOT := ../../../../../nRF5_SDK_12.3.0_d7731ad
 PROJ_DIR := ../../..
 
 $(OUTPUT_DIRECTORY)/eddystone.out: \
-  LINKER_SCRIPT  := eddystone.ld
+  LINKER_SCRIPT := eddystone.ld
 
 # Source files common to all targets
 SRC_FILES += \
@@ -305,7 +305,6 @@ LDFLAGS += -Wl,--gc-sections
 # use newlib in nano version
 LDFLAGS += --specs=nano.specs -lc -lnosys
 
-
 .PHONY: $(TARGETS) default all clean
 
 # Default target - first one defined
@@ -314,10 +313,9 @@ default: eddystone
 # Print all targets that can be built
 help:
 	@echo following targets are available:
-	@echo 	eddystone
+	@echo   eddystone
 
 TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
 
 include $(TEMPLATE_PATH)/Makefile.common
-
 $(foreach target, $(TARGETS), $(call define_target, $(target)))

--- a/ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc/Makefile
+++ b/ruuvi_examples/ruuvi_firmware/ruuvitag_b/s132/armgcc/Makefile
@@ -6,7 +6,8 @@ SDK_ROOT := ../../../../../nRF5_SDK_12.3.0_d7731ad
 PROJ_DIR := ../../..
 
 $(OUTPUT_DIRECTORY)/ruuvi_firmware.out: \
-  LINKER_SCRIPT  := ruuvi_firmware.ld
+  LINKER_SCRIPT := ruuvi_firmware.ld
+
 # Source files common to all targets
 SRC_FILES += \
   $(PROJ_DIR)/../../bsp/bsp.c \
@@ -208,7 +209,6 @@ INC_FOLDERS += \
   $(SDK_ROOT)/components/toolchain/gcc \
   $(SDK_ROOT)/external/segger_rtt \
 
-
 # Libraries common to all targets
 LIB_FILES += \
 
@@ -286,20 +286,15 @@ LDFLAGS += -Wl,--gc-sections
 # use newlib in nano version
 LDFLAGS += --specs=nano.specs -lc -lnosys
 
-
-
-
-
-
-
 .PHONY: $(TARGETS) default all clean help
+
 # Default target - first one defined
 default: ruuvi_firmware
 
 # Print all targets that can be built
 help:
 	@echo following targets are available:
-	@echo ruuvi_firmware
+	@echo   ruuvi_firmware
 
 TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
 

--- a/ruuvi_examples/test_drivers/ruuvitag_b/s132/armgcc/Makefile
+++ b/ruuvi_examples/test_drivers/ruuvitag_b/s132/armgcc/Makefile
@@ -7,7 +7,8 @@ IOTA_ROOT := ../../../../../iota.lib.c
 PROJ_DIR := ../../..
 
 $(OUTPUT_DIRECTORY)/test_drivers.out: \
-  LINKER_SCRIPT  := test_drivers.ld
+  LINKER_SCRIPT := test_drivers.ld
+
 # Source files common to all targets
 SRC_FILES += \
   $(SDK_ROOT)/components/ble/common/ble_advdata.c \
@@ -294,18 +295,18 @@ LDFLAGS += -Wl,--gc-sections
 LDFLAGS += --specs=nano.specs -lc -lnosys
 
 .PHONY: $(TARGETS) default all clean help
+
 # Default target - first one defined
 default: test_drivers
 
 # Print all targets that can be built
 help:
 	@echo following targets are available:
-	@echo 	test_drivers
-	@echo 	flash_softdevice
+	@echo   test_drivers
+	@echo   flash_softdevice
 
 TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
 
 include $(TEMPLATE_PATH)/Makefile.common
 $(foreach target, $(TARGETS), $(call define_target, $(target)))
 -include $(foreach target, $(TARGETS), $($(target)_dependencies))
-


### PR DESCRIPTION
Cleaned up the Makefiles, mainly whitespace to make the structure more consistent.

Removed the "distro" target in the main Makefile, as it was using a gdrive (Google Drive) command that we cannot expect normal users of the project to need/use. And #62 already favored using the GitHub releases, so the distro/gdrive approach was probably not in active use either.

In the main Makefile, also slightly changed build order: putting ruuvi_firmware before test_drivers. Note that this only alphabetical ordering within the ruuvi_examples.