### PR TITLE
Add NFC callbacks

### DIFF
--- a/drivers/nrf_nordic_nfc/nfc.c
+++ b/drivers/nrf_nordic_nfc/nfc.c
@@ -18,10 +18,10 @@
 //Do not compile RAM-consuming buffers if they're not used
 #if NFC_HAL_ENABLED
 
-
 uint8_t m_ndef_msg_buf[256];
 bool nfc_is_init = false;
 volatile bool field_on = false;
+nfc_callback_t app_callback = NULL;
 
 /**
  * @brief Callback function for handling NFC events.
@@ -47,6 +47,7 @@ void nfc_callback(void * p_context, nfc_t2t_event_t event, const uint8_t * p_dat
         default:
             break;
     }
+    if(NULL != app_callback) { app_callback(p_context, event, p_data, data_length); } 
 }
 
 /**
@@ -65,7 +66,7 @@ void nfc_msg_encode(nfc_ndef_msg_desc_t* nfc_msg, uint8_t * p_buffer, uint32_t *
     /** @snippet [NFC text usage_2] */
 }
 
-uint32_t nfc_init(uint8_t* data, uint32_t data_length)
+ret_code_t nfc_init(uint8_t* data, uint32_t data_length)
 {
     if(field_on) { return NRF_ERROR_INVALID_STATE; }
     NFC_NDEF_MSG_DEF(nfc_msg, MAX_REC_COUNT);
@@ -195,6 +196,11 @@ void address_record_add(nfc_ndef_msg_desc_t* nfc_msg)
     err_code = nfc_ndef_msg_record_add(nfc_msg,
                                        &NFC_NDEF_TEXT_RECORD_DESC(id_text_rec));
     APP_ERROR_CHECK(err_code);
+}
+
+void set_nfc_callback(nfc_callback_t callback)
+{
+  app_callback = callback;
 }
 
 #endif

--- a/drivers/nrf_nordic_nfc/nfc.h
+++ b/drivers/nrf_nordic_nfc/nfc.h
@@ -5,6 +5,7 @@
 #include "nfc_t2t_lib.h"
 #include "nfc_ndef_msg.h"
 #include "nfc_text_rec.h"
+#include "sdk_errors.h"
 
 #define MAX_REC_COUNT      3     /**< Maximum records count. */
 
@@ -16,7 +17,7 @@
  * @return error  code from NFC init, 0 on success
  *
  */
-uint32_t nfc_init(uint8_t* data, uint32_t data_length);
+ret_code_t nfc_init(uint8_t* data, uint32_t data_length);
 
 /**
  * @brief Function for encoding the NFC message.
@@ -43,5 +44,14 @@ void data_record_add(nfc_ndef_msg_desc_t* nfc_msg, uint8_t* data, uint32_t data_
  * @brief Callback function for handling NFC events.
  */
 void nfc_callback(void * p_context, nfc_t2t_event_t event, const uint8_t * p_data, size_t data_length);
+
+/*
+ * Set callback which will be called once NFC event is received. NULL to disable callback
+ * Takes effect after NFC init
+ */
+typedef void(*nfc_callback_t)(void*, nfc_t2t_event_t, const uint8_t*, size_t);
+void set_nfc_callback(nfc_callback_t callback);
+
+
 
 #endif

--- a/drivers/nrf_nordic_nfc/nrf_nfc_handler.c
+++ b/drivers/nrf_nordic_nfc/nrf_nfc_handler.c
@@ -1,0 +1,48 @@
+#include "nrf_nfc_handler.h"
+
+#include "nfc.h"
+#include "ruuvi_endpoints.h"
+
+//Do not compile RAM-consuming buffers if they're not used
+#if NFC_HAL_ENABLED
+
+static message_handler nfc_connected_handler = NULL;
+
+/**
+ * Handler gets called when NFC event occurs
+ */
+void nfc_connected_handler_set(message_handler handler)
+{
+  nfc_connected_handler = handler;
+}
+
+static void nfc_event_handle(void * p_context, nfc_t2t_event_t event, const uint8_t * p_data, size_t data_length)
+{
+    (void)p_context;
+    ruuvi_standard_message_t message;
+    memset(&message, 0, sizeof(message));
+    message.source_endpoint = NFC;
+
+    switch (event)
+    {
+        case NFC_T2T_EVENT_FIELD_ON:
+            if(NULL != nfc_connected_handler) { nfc_connected_handler(message); }
+            break;
+        case NFC_T2T_EVENT_FIELD_OFF:
+            break;
+        case NFC_T2T_EVENT_DATA_READ:
+            break;
+        default:
+            break;
+    }
+}
+
+/**
+ * Sets up callback to handler
+ */
+void nfc_init_handler(void)
+{
+  set_nfc_callback(nfc_event_handle);
+}
+
+#endif

--- a/drivers/nrf_nordic_nfc/nrf_nfc_handler.h
+++ b/drivers/nrf_nordic_nfc/nrf_nfc_handler.h
@@ -1,0 +1,21 @@
+/**
+ * Handler for NFC events, allows registering callbacks from the NFC driver into application
+ *
+ * Usage: call nfc_init_handler() to register handler into NFC driver. 
+ * Set callbacks, i.e. nfc_connected handler_set(my_handler)
+ * Init NFC, i.e. nfc_init (or init_nfc if you're using Ruuvi Init driver)
+ * 
+ * Author: Otso Jousimaa <otso@ruuvi.com>
+ * License: BSD-3
+ */
+
+#ifndef NRF_NFC_HANDLER_H
+#define NRF_NFC_HANDLER_H
+
+#include "sdk_errors.h"
+#include "ruuvi_endpoints.h"
+
+void nfc_connected_handler_set(message_handler handler);
+void nfc_init_handler(void);
+
+#endif

--- a/libraries/ruuvi_sensor_formats/ruuvi_endpoints.h
+++ b/libraries/ruuvi_sensor_formats/ruuvi_endpoints.h
@@ -13,6 +13,7 @@ typedef enum{
   BATTERY                 = 0x20, // Battery state message
   RNG                     = 0x21, // Random number
   RTC                     = 0x22, // Real time clock 
+  NFC                     = 0x23, // NFC message
   TEMPERATURE             = 0x31, // Temperature message
   HUMIDITY                = 0x32,
   PRESSURE                = 0x33,

--- a/ruuvi_examples/eddystone/es_app_config.h
+++ b/ruuvi_examples/eddystone/es_app_config.h
@@ -96,7 +96,7 @@
 /** @brief This value should mimic the data that would be written to the RW ADV Slot characteristic (for example, no RSSI for UID). */
 #define DEFAULT_FRAME_DATA              {DEFAULT_FRAME_TYPE, DEFAULT_FRAME_TX_POWER, APP_ES_URL_SCHEME, APP_ES_URL_URL}
 #define DEFAULT_FRAME_LENGTH            15                                //!< 1 - Frame Type, 1 - TX - power 1 - URL Scheme, URL - 12 = 15
-#define APP_CFG_CONNECTABLE_ADV_TIMEOUT 60
+#define APP_CFG_CONNECTABLE_ADV_TIMEOUT 60                                //!< seconds
 #define APP_CFG_DEFAULT_RADIO_TX_POWER  4
 
 #endif //End include guard

--- a/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
+++ b/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
@@ -94,6 +94,7 @@ SRC_FILES += \
   $(SDK_ROOT)/components/drivers_nrf/spi_master/nrf_drv_spi.c \
   $(SDK_ROOT)/components/drivers_nrf/uart/nrf_drv_uart.c \
   $(SDK_ROOT)/components/drivers_nrf/hal/nrf_saadc.c \
+  $(SDK_ROOT)/components/drivers_nrf/wdt/nrf_drv_wdt.c \
   $(SDK_ROOT)/components/softdevice/common/softdevice_handler/softdevice_handler.c \
   $(SDK_ROOT)/components/ble/ble_advertising/ble_advertising.c \
   $(SDK_ROOT)/components/ble/ble_services/ble_dfu/ble_dfu.c \

--- a/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
+++ b/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
@@ -28,11 +28,12 @@ SRC_FILES += \
   $(PROJ_DIR)/../../drivers/init/init.c \
   $(PROJ_DIR)/../../drivers/lis2dh12/lis2dh12.c \
   $(PROJ_DIR)/../../drivers/lis2dh12/lis2dh12_acceleration_handler.c \
+  $(PROJ_DIR)/../../drivers/nrf_nordic_nfc/nfc.c \
+  $(PROJ_DIR)/../../drivers/nrf_nordic_nfc/nrf_nfc_handler.c \
   $(PROJ_DIR)/../../drivers/nrf_nordic_pininterrupt/pin_interrupt.c \
+  $(PROJ_DIR)/../../drivers/nrf_nordic_watchdog/watchdog.c \
   $(PROJ_DIR)/../../drivers/pwm/pwm.c \
   $(PROJ_DIR)/../../drivers/spi/spi.c \
-  $(PROJ_DIR)/../../drivers/nrf_nordic_nfc/nfc.c \
-  $(PROJ_DIR)/../../drivers/nrf_nordic_watchdog/watchdog.c \
   $(PROJ_DIR)/../../libraries/ruuvi_sensor_formats/ruuvi_endpoints.c \
   $(PROJ_DIR)/../../libraries/ruuvi_sensor_formats/chain_channels.c \
   $(PROJ_DIR)/../../libraries/data_structures/ringbuffer.c \

--- a/ruuvi_examples/eddystone/sdk_application_config.h
+++ b/ruuvi_examples/eddystone/sdk_application_config.h
@@ -22,5 +22,12 @@
 #define PEER_MANAGER_ENABLED 1
 #define BLE_DIS_ENABLED 1
 
+// WDT_CONFIG_RELOAD_VALUE - Reload value  <15-4294967295> (ms)
+// Watchdog cannot be stopped even when entering bootloader, 
+// so use 6 minutes to allow DFU process to complete.
+#ifndef WDT_CONFIG_RELOAD_VALUE
+#define WDT_CONFIG_RELOAD_VALUE 360000 
+#endif
+
 #endif
 


### PR DESCRIPTION
Eddystone FW now enters connectable mode after tag is read with NFC.
Build is passing, [![Build Status](http://jenkins.ruuvi.com:8080/buildStatus/icon?job=ruuvitag_fw-ojousima&build=23)](http://jenkins.ruuvi.com:8080/job/ruuvitag_fw-ojousima/23/)