### PR TITLE
Enable application timer RTC to keep track of eddystone time

### DIFF
--- a/ruuvi_examples/eddystone/sdk_application_config.h
+++ b/ruuvi_examples/eddystone/sdk_application_config.h
@@ -8,11 +8,15 @@
 #define APP_PWM_ENABLED 0
 #define PPI_ENABLED 1
 #define RTC_ENABLED 1
-#define TIMER_ENABLED 1
-#define TIMER0_ENABLED 1
-#define TIMER1_ENABLED 1  //CSense
-#define TIMER2_ENABLED 1  //CSense
-#define TIMER3_ENABLED 1
+#define RTC0_ENABLED 0  // Used by softdevice, don't enable for application
+#define RTC1_ENABLED 0  // Used by Eddystone libs
+#define RTC2_ENABLED 1  // used by application RTC
+#define APP_TIMER_KEEPS_RTC_ACTIVE 1 // Used by eddystone to keep track of time 
+#define TIMER_ENABLED 0
+#define TIMER0_ENABLED 0
+#define TIMER1_ENABLED 0  //CSense
+#define TIMER2_ENABLED 0  //CSense
+#define TIMER3_ENABLED 0
 #define TIMER4_ENABLED 0  //Required by NFC
 #define NFC_HAL_ENABLED 1
 #define CRC16_ENABLED 1   //Required by DFU


### PR DESCRIPTION
Fixes issue of application on-time, battery voltage and temperature not updating on TLM frames