### PR TITLE
Use fixed Eddystone TLM code with board-specific diode drop

### DIFF
--- a/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
+++ b/ruuvi_examples/eddystone/ruuvitag_b/s132/armgcc/Makefile
@@ -61,7 +61,6 @@ SRC_FILES += \
   $(SDK_ROOT)/components/libraries/eddystone/es_adv_frame.c \
   $(SDK_ROOT)/components/libraries/eddystone/es_adv_timing.c \
   $(SDK_ROOT)/components/libraries/eddystone/es_adv_timing_resolver.c \
-  $(SDK_ROOT)/components/libraries/eddystone/es_battery_voltage_saadc.c \
   $(SDK_ROOT)/components/libraries/eddystone/es_flash.c \
   $(SDK_ROOT)/components/libraries/eddystone/es_gatts.c \
   $(SDK_ROOT)/components/libraries/eddystone/es_gatts_read.c \


### PR DESCRIPTION
Jenkins build is passing,
[![Build Status](http://jenkins.ruuvi.com:8080/buildStatus/icon?job=ruuvitag_fw-ojousima&build=33)](http://jenkins.ruuvi.com:8080/job/ruuvitag_fw-ojousima/33/)