### PR TITLE
Add basic model support to eddystone

### DIFF
--- a/ruuvi_examples/eddystone/bluetooth_application_config.h
+++ b/ruuvi_examples/eddystone/bluetooth_application_config.h
@@ -8,7 +8,7 @@
 #define APPLICATION_ADV_INTERVAL        500                             /**< ms **/
 #define APP_TX_POWER                    4                               /**< dBm **/
 
-#define INIT_FWREV                          "Eddystone 1.3.5"                             /**< Github tag **/
+#define INIT_FWREV                          "Eddystone 1.3.6"                             /**< Github tag **/
 #define INIT_SWREV                          INIT_FWREV                                    /**< Practicially same thing, as there is no separate SW **/
 
 #endif

--- a/ruuvi_examples/eddystone/main.c
+++ b/ruuvi_examples/eddystone/main.c
@@ -183,7 +183,13 @@ int main(void)
   err_code |= init_ble(); 
   err_code |= bluetooth_configure_advertisement_type(BLE_GAP_ADV_TYPE_ADV_NONCONN_IND);
 
-  err_code |= init_sensors();
+  // Call sensor init to ensure that sensors will be in low-power mode
+  // Do not OR error code, as eddystone works without sensors and
+  // we want to support basic model
+  if (NRF_SUCCESS == init_sensors())
+  {
+    NRF_LOG_INFO("SENSORS INIT \r\n");
+  }
 
   NRF_LOG_DEBUG("BLE init status: %d\r\n", err_code);
 


### PR DESCRIPTION
Does not crash on sensor self-test fail. 
[![Build Status](http://jenkins.ruuvi.com:8080/buildStatus/icon?job=ruuvitag_fw-ojousima&build=72)](http://jenkins.ruuvi.com:8080/job/ruuvitag_fw-ojousima/72/)