### PR TITLE
Add tap detection support to lis2dh12 driver

### DIFF
--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -295,13 +295,15 @@ lis2dh12_ret_t lis2dh12_set_activity_interrupt_pin_2(uint16_t mg)
     // //CTRLREG2 = 0x02
     // ctrl[0] = LIS2DH12_HPIS2_MASK;
     // lis2dh12_write_register(LIS2DH12_CTRL_REG2, ctrl, 1);
-
-    lis2dh12_set_highpass(LIS2DH12_HPIS2_MASK);
+    lis2dh12_read_register(LIS2DH12_CTRL_REG2, &cfg, 1);
+    cfg |= LIS2DH12_HPIS2_MASK;
+    lis2dh12_write_register(LIS2DH12_CTRL_REG2, &cfg, 1);
 
     // Enable interrupt 2 on X-Y-Z HI/LO.
     // INT2_CFG = 0x7F
     // ctrl[0] = 0x7F;
     // lis2dh12_write_register(LIS2DH12_INT2_CFG, ctrl, 1);
+    cfg = 0;
     cfg |= LIS2DH12_6D_MASK | LIS2DH12_ZHIE_MASK | LIS2DH12_ZLIE_MASK;
     cfg |= LIS2DH12_YHIE_MASK | LIS2DH12_YLIE_MASK;
     cfg |= LIS2DH12_XHIE_MASK | LIS2DH12_XLIE_MASK;
@@ -358,19 +360,6 @@ lis2dh12_ret_t lis2dh12_set_interrupt_configuration(uint8_t cfg, uint8_t functio
   uint8_t target_reg = LIS2DH12_INT1_CFG;
   if( 2 == function ) { target_reg = LIS2DH12_INT2_CFG; }
   return lis2dh12_write_register(target_reg, ctrl, 1);
-}
-
-/**
- * Setup high-pass functions of lis2dh12. Select mode, cutoff frequency, filter data, click, interrputs.
- *
- * @param highpass byte to write to filter, resets previous settings.
- * @return error code from SPI write. 
- */
-lis2dh12_ret_t lis2dh12_set_highpass(uint8_t highpass)
-{
-    uint8_t ctrl[1];
-    ctrl[0] = highpass;
-    return lis2dh12_write_register(LIS2DH12_CTRL_REG2, ctrl, 1);
 }
 
 /**

--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -287,6 +287,7 @@ lis2dh12_ret_t lis2dh12_set_fifo_watermark(size_t count)
  */
 lis2dh12_ret_t lis2dh12_set_activity_interrupt_pin_2(uint16_t mg)
 {
+    uint8_t cfg = 0;
 
     // // Configure activity interrupt - TODO: Implement in driver, add tests.
     // uint8_t ctrl[1];
@@ -301,7 +302,10 @@ lis2dh12_ret_t lis2dh12_set_activity_interrupt_pin_2(uint16_t mg)
     // INT2_CFG = 0x7F
     // ctrl[0] = 0x7F;
     // lis2dh12_write_register(LIS2DH12_INT2_CFG, ctrl, 1);
-    lis2dh12_set_interrupt_configuration(0x7F, 2);
+    cfg |= LIS2DH12_6D_MASK | LIS2DH12_ZHIE_MASK | LIS2DH12_ZLIE_MASK;
+    cfg |= LIS2DH12_YHIE_MASK | LIS2DH12_YLIE_MASK;
+    cfg |= LIS2DH12_XHIE_MASK | LIS2DH12_XLIE_MASK;
+    lis2dh12_set_interrupt_configuration(cfg, 2);
     // Interrupt on 64 mg+ (highpassed, +/-).
     //INT2_THS= 0x04 // 4 LSB = 64 mg @2G scale
     // ctrl[0] = LIS2DH12_ACTIVITY_THRESHOLD;

--- a/drivers/lis2dh12/lis2dh12.h
+++ b/drivers/lis2dh12/lis2dh12.h
@@ -181,14 +181,6 @@ lis2dh12_ret_t lis2dh12_set_interrupts(uint8_t interrupts, uint8_t pin);
 lis2dh12_ret_t lis2dh12_set_interrupt_configuration(uint8_t cfg, uint8_t function);
 
 /**
- * Setup high-pass functions of lis2dh12. Select mode, cutoff frequency, filter data, click, interrputs.
- *
- * @param highpass byte to write to filter, resets previous settings.
- * @return error code from SPI write. 
- */
-lis2dh12_ret_t lis2dh12_set_highpass(uint8_t highpass);
-
-/**
  *  Setup number of LSBs needed to trigger AOI interrupt function. 
  *  Note: this targets function 1 or 2, not pin. 
  *

--- a/drivers/lis2dh12/lis2dh12.h
+++ b/drivers/lis2dh12/lis2dh12.h
@@ -119,6 +119,11 @@ lis2dh12_ret_t lis2dh12_enable(void);
 lis2dh12_ret_t lis2dh12_set_scale(lis2dh12_scale_t scale);
 
 /**
+ * Return full scale in mg for current state
+ */
+int lis2dh12_get_full_scale();
+
+/**
  *  Select resolution. FIFO is 10 bits, 12 bit mode has lower bandwidth than 10 and 8 bit modes.
  *  Higher resolution consumes more power.
  *  Returns error code from SPI write
@@ -130,6 +135,16 @@ lis2dh12_ret_t lis2dh12_set_resolution(lis2dh12_resolution_t resolution);
  *  Returns error code from SPI write
  */
 lis2dh12_ret_t lis2dh12_set_sample_rate(lis2dh12_sample_rate_t sample_rate);
+
+/**
+ * Get sample rate.
+ */
+lis2dh12_ret_t lis2dh12_get_sample_rate(lis2dh12_sample_rate_t *sample_rate);
+
+/**
+ * Convert sample_rate values to frequency.
+ */
+int lis2dh12_odr_to_hz(lis2dh12_sample_rate_t sample_rate);
 
 /**
  *  Select FIFO mode. Bypass: FIFO not used. FIFO: FIFO fills and "freezes" until FIFO reset by setting mode to bypass.
@@ -205,6 +220,11 @@ lis2dh12_ret_t lis2dh12_set_activity_threshold(uint8_t bits);
  * Enable activity detection interrupt on pin 2. Interrupt is high for samples where high-passed acceleration exceeds mg
  */
 lis2dh12_ret_t lis2dh12_set_activity_interrupt_pin_2(uint16_t mg);
+
+/**
+ * Enable tap detection interrupt on given pin with click_cfg, threshold and time limit, window and latency.
+ */
+lis2dh12_ret_t lis2dh12_set_tap_interrupt(uint8_t click_cfg, int threshold_mg, int timelimit_ms, int latency_ms, int window_ms, uint8_t pin);
 
 /**
  *  Internal functions for reading/writing registers. 


### PR DESCRIPTION
This PR adds code (and a little bit of documentation) to enable single or double tap detection with the lis2dh12 accelerometer.

Included are also two commits improving the lis2dh12 configuration when setting the activity interrupt.