### PR TITLE
Purge FDS on long press

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ The firmware is built on Nordic SDK 12.3 and uses Softdevice S132 v3.1.1.
 
 ## 2.x
 RuuviTags manufactured in 2020 ship with Ruuvi Firmware 2.5.9.
-The firmware broadcasts in RAWv2 format by default, but you can enter to RAWv1 mode which is compatible with 
-1.2.12 by pressing button "B" twice. Red led blinks while in legacy mode and green led blinks while in modern mode. 
+The firmware broadcasts in RAWv2 format by default, but you can enter to RAWv1 mode which is compatible with 1.2.12 by pressing button "B" twice. Red led blinks while in legacy mode and green led blinks while in modern mode. 
 The firmware is built on Nordic SDK 12.3 and uses Softdevice S132 v3.1.1, generally switching between 
 1.x and 2.x applications is easy.
 

--- a/drivers/nrf_nordic_flash/flash.c
+++ b/drivers/nrf_nordic_flash/flash.c
@@ -299,4 +299,27 @@ ret_code_t flash_init(void)
   rc |= fds_stat(&stat);
   return rc;
 }
+
+ret_code_t flash_purge(void)
+{
+    ret_code_t err_code = NRF_SUCCESS;
+#if   defined(NRF51)
+        int erase_unit = 1024;
+#elif defined(NRF52_SERIES)
+        int erase_unit = 4096;
+#endif
+    const size_t end_address = 0x75000; // Start of bootloader.
+    // Start of flash pages
+    const size_t start_address = end_address - (FDS_PHY_PAGES * erase_unit);
+
+    for (int p = 0; p < FDS_PHY_PAGES; p++)
+    {
+
+        int page = (start_address / erase_unit) + p;
+        err_code |= sd_flash_page_erase (page);
+        nrf_delay_ms(200);
+    }
+    return err_code;
+}
+
 #endif

--- a/drivers/nrf_nordic_flash/flash.h
+++ b/drivers/nrf_nordic_flash/flash.h
@@ -14,6 +14,8 @@ ret_code_t flash_record_get(const uint32_t page_id, const uint32_t record_id, co
 ret_code_t flash_record_set(const uint32_t page_id, const uint32_t record_id, const size_t data_size, const void* const data);
 ret_code_t flash_free_size_get(size_t* size);
 
+ret_code_t flash_purge(void);
+
 
 
 #endif

--- a/ruuvi_examples/ruuvi_firmware/bluetooth_application_config.h
+++ b/ruuvi_examples/ruuvi_firmware/bluetooth_application_config.h
@@ -5,7 +5,7 @@
 #define APP_DEVICE_NAME                 APPLICATION_DEVICE_NAME         /**< TODO: Refactoring **/
 #define APP_DEVICE_NAME_LENGTH          APPLICATION_DEVICE_NAME_LENGTH
 #define APP_TX_POWER                    4                               /**< dBm **/
-#define INIT_FWREV                      "2.5.9"                         /**< Github tag. Do not include specifiers such as "alpha" so you can accept ready binaries as they are **/
+#define INIT_FWREV                      "2.6.0"                         /**< Github tag. Do not include specifiers such as "alpha" so you can accept ready binaries as they are **/
 #define INIT_SWREV                      INIT_FWREV                      /**< FW and SW are same thing in this context **/                             
 
 // milliseconds until main loop timer function is called. Other timers can bring

--- a/ruuvi_examples/ruuvi_firmware/main.c
+++ b/ruuvi_examples/ruuvi_firmware/main.c
@@ -228,7 +228,10 @@ static void reboot(void* p_context)
   // if we have registered a button press and the button is still pressed (debounce)
   if(!pressed || (pressed && !(nrf_gpio_pin_read(BUTTON_1))))
   {
-    NRF_LOG_WARNING("Rebooting\r\n")
+    NRF_LOG_WARNING("Erasing Flash and rebooting\r\n");
+    app_timer_stop(main_timer_id);
+    bluetooth_advertising_stop();
+    flash_purge();
     NVIC_SystemReset();
   }
   pressed = false;


### PR DESCRIPTION
This should fix issue where Espruino won't boot when RuuviTag has old data in flash. 